### PR TITLE
Profile欄の経歴追加

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -17,3 +17,44 @@ span {
   top: 50%;
   transform: translateY(-50%);
 }
+
+.white-background-area {
+  position: relative;
+  width: 100%;
+  height: 500px;
+  background: white;
+}
+
+.vertical-line {
+  position: absolute;
+  width: 3px;
+  height: 500px;
+  background-color: #edb882;
+}
+
+.border-radius {
+  position: relative;
+  left: -8.5px;
+  width: 20px;
+  height: 20px;
+  background-color: #7d4712;
+  border-radius: 50%;
+  text-align: center;
+}
+
+.character-year {
+  position: relative;
+  top: -9px;
+  font-family: "Courier New";
+  font-weight: bold;
+  font-size: 28px;
+  color: #7d4712;
+}
+
+.character-title {
+  position: relative;
+  top: -4.5px;
+  font-family: "Courier New";
+  font-weight: bold;
+  font-size: 24px;
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -11,3 +11,9 @@ span {
   padding: 10px;
   background-color: #edb882;
 }
+
+.vertical-middle {
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+}

--- a/index.html
+++ b/index.html
@@ -39,8 +39,72 @@
             </div>
           </div>
         </div>
-      </div>
+        <div class="px-5">
+          <div class="white-background-area">
+            <div class="vertical-line"></div>
+            <div class="row">
+              <!-- 1997年 -->
+              <div class="col-sm-2">
+                <div class="border-radius">
+                  <div class="px-5 character-year">1997</div>
+                </div>
+              </div>
+              <div class="col-sm-10">
+                <div class="character-title">長野県松本市に生まれる</div>
+              </div>
+              <div class="w-100 my-4"></div>
 
+              <!-- 2016年 -->
+              <div class="col-sm-2">
+                <div class="border-radius">
+                  <div class="px-5 character-year">2016</div>
+                </div>
+              </div>
+              <div class="col-sm-10">
+                <div class="character-title">千葉大学工学部 入学</div>
+                <p>
+                  大学では、物理化学系の学問を専攻。<br />
+                  大学3年生で初学者向け(PHP)のプログラミングインターンに2ヶ月参画。<br />
+                  大学4年生〜
+                  AIを用いた画像認識(Matlab,Python)の研究に3年間従事。<br />
+                </p>
+              </div>
+              <div class="w-100 my-4"></div>
+
+              <!-- 2022年 -->
+              <div class="col-sm-2">
+                <div class="border-radius">
+                  <div class="px-5 character-year">2022</div>
+                </div>
+              </div>
+              <div class="col-sm-10">
+                <div class="character-title">
+                  大手人材会社へITエンジニア職として入社
+                </div>
+                <p>
+                  半年間の研修を経て、2022年10月に本配属。<br />
+                  2022年10月〜
+                  保守開発案件(言語:PHP/Laravel)に内製開発で従事。<br />
+                  2023年4月〜 新規開発案件(言語:Ruby/Ruby on
+                  Rails)に内製開発で従事。<br />
+                </p>
+              </div>
+              <div class="w-100 my-4"></div>
+
+              <!-- 2024年 -->
+              <div class="col-sm-2">
+                <div class="border-radius">
+                  <div class="px-5 character-year">2024</div>
+                </div>
+              </div>
+              <div class="col-sm-10">
+                <div class="character-title">現在に至る</div>
+              </div>
+              <div class="w-100 my-4"></div>
+            </div>
+          </div>
+        </div>
+      </div>
       <!-- 02.Skill -->
       <div class="my-5">
         <h1><span>02</span> Skill</h1>

--- a/index.html
+++ b/index.html
@@ -22,28 +22,21 @@
       <!-- 01.Profile -->
       <div class="my-5">
         <h1><span>01</span> Profile</h1>
-        <h2>名前：Yuto</h2>
         <div class="row">
-          <div class="col-sm-3 my-auto">
+          <div class="col-sm-6 my-5">
             <img
               src="assets/images/profile.jpg"
               alt="profile"
-              width="150"
-              height="150"
+              width="300"
+              height="300"
               class="mx-auto d-block rounded-circle"
             />
           </div>
-          <div class="col-sm-9">
-            エンジニア3年目/バックエンドエンジニア<br /><br />
-            【経歴】
-            <ul>
-              <li>1997年 - 長野県松本市で長男として生まれる</li>
-              <li>2020年 - 千葉大学卒業</li>
-              <li>2022年 - 千葉大学大学院卒業</li>
-              <li>
-                現在 - ITエンジニアとして事業会社へ就職。現在3年目に至る。
-              </li>
-            </ul>
+          <div class="col-sm-6">
+            <div class="vertical-middle">
+              <h2 class="fw-bold">松岡 雄斗</h2>
+              <p>社会人3年目 / バックエンドエンジニア</p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 対応内容

Profileの自己紹介欄及び経歴をスライドに倣って追加しました。

▼自己紹介欄
https://docs.google.com/presentation/d/1OJE_toiS___WhHEdtO9JTj_rwSbI4NHDf5VwL-x12V0/edit#slide=id.p

▼経歴欄
https://docs.google.com/presentation/d/1OJE_toiS___WhHEdtO9JTj_rwSbI4NHDf5VwL-x12V0/edit#slide=id.g3016f90028e_0_66

▼イメージ
<img width="894" alt="スクリーンショット 2024-11-18 22 09 52" src="https://github.com/user-attachments/assets/f5d8eb45-c024-42d7-847f-a9f3ce3357c0">